### PR TITLE
Remove arbitrary font names from cssFontAttr and add dash to iskeyword.

### DIFF
--- a/syntax/css.vim
+++ b/syntax/css.vim
@@ -23,6 +23,8 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 syn case ignore
+" Add dash to allowed keyword characters.
+syn iskeyword @,48-57,_,192-255,-
 
 " HTML4 tags
 syn keyword cssTagName abbr address area a b base
@@ -234,9 +236,7 @@ syn keyword cssFontAttr contained larger smaller
 syn match cssFontAttr contained "\<\(x\{1,2\}-\)\=\(large\|small\)\>"
 syn match cssFontAttr contained "\<small-\(caps\|caption\)\>"
 " font-family attributes
-syn match cssFontAttr contained "\<\(sans-\)\=serif\>"
-syn keyword cssFontAttr contained Antiqua Arial Black Book Charcoal Comic Courier Dingbats Gadget Geneva Georgia Grande Helvetica Impact Linotype Lucida MS Monaco Neue New Palatino Roboto Roman Symbol Tahoma Times Trebuchet Verdana Webdings Wingdings York Zapf
-syn keyword cssFontAttr contained cursive fantasy monospace
+syn keyword cssFontAttr contained sans-serif serif cursive fantasy monospace
 " font-feature-settings attributes
 syn keyword cssFontAttr contained on off
 " font-stretch attributes

--- a/test.css
+++ b/test.css
@@ -293,3 +293,8 @@ and (max-device-width:1024px)
    padding: var(--pad, 10px 15px 20px);
    color: var(--foo, #7F583F);
 }
+
+#issue6 {
+  font-family: Roboto, Helvetica, test-serif, testing-sans-serif;
+  font-family: monospace, cursive, fantasy, serif, sans-serif
+}


### PR DESCRIPTION
Closes #6.

----

The `syn iskeyword` line copies the default value of 'iskeyword' and adds a dash. This allows `syn keyword` statements to include dashes in the keywords. There may be some parts of the syntax file that can be refactored to use `syn keyword` instead of `syn match` now, but I didn't look closely since I wanted to keep the commit focused.

I also added a test case to show that font names like 'test-serif' aren't erroneously matched anymore.